### PR TITLE
Fix libxml2 submodule location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libxml2"]
 	path = libxml2
-	url = git://git.gnome.org/libxml2
+	url = https://gitlab.gnome.org/GNOME/libxml2.git


### PR DESCRIPTION
git.gnome.org was decommissioned, submodule no longer installs

https://mail.gnome.org/archives/desktop-devel-list/2018-August/msg00010.html