### PR TITLE
Reduce xmllint to ~2MB

### DIFF
--- a/script/compile
+++ b/script/compile
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-emcc -O2 -s EMULATE_FUNCTION_POINTER_CASTS=1 \
+emcc -Oz -s WASM=0 -s EMULATE_FUNCTION_POINTER_CASTS=1 \
 	--memory-init-file 0 \
 	./build/xmllint.o ./build/.libs/libxml2.a ./libz.a \
 	-o xmllint.raw.js --pre-js ./src/pre.js

--- a/script/libxml2
+++ b/script/libxml2
@@ -5,6 +5,6 @@ mkdir -p ./libxml2/m4
 cd ./libxml2
 autoreconf -if -Wall
 cd ../build
-emconfigure ../libxml2/configure --with-http=no --with-ftp=no --with-python=no --with-threads=no
+emconfigure ../libxml2/configure --with-minimum=yes --with-python=no --with-threads=no --with-schemas=yes
 emmake make
 cd ..


### PR DESCRIPTION
…e0322acb60868750697ca03aab

I just adjust some parameter in the scripts. Maybe you will like it. Webassembly isn't supported by every browser and won't needed anymore.
--with-minimum will reduce xmllint to ~2MB.