### PR TITLE
Add support for validation against RELAX NG schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+This branch adds an optional field to the options given to the validateXML function.
+If the user adds a field "format" with the content "rng", then the
+argument used will be "--relaxng" instead of "--schema". Otherwise
+"--schema" is used.
+
 
 Online demo at http://syssgx.github.com/xml.js/
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 This branch adds an optional field to the options given to the validateXML function.
-If the user adds a field "format" with the content "rng", then the
-argument used will be "--relaxng" instead of "--schema". Otherwise
-"--schema" is used.
+If the user adds a field ```format``` with the content ```rng```, then the
+argument used will be ```--relaxng``` instead of ```--schema```. Otherwise
+```--schema``` is used.
 
+-----------------------------------------------------------------------------------
 
 Online demo at http://syssgx.github.com/xml.js/
 

--- a/src/pre.js
+++ b/src/pre.js
@@ -23,7 +23,7 @@ Module.arguments = ['--noout'];
 		Module['xml'] = [Module['xml']];
 	}
 	for (i = 0; i < Module['schema'].length; i++) {
-		Module.arguments.push('--schema');
+		Module.arguments.push(Module['extension']);
 		Module.arguments.push('file_' + i + '.xsd');
 	}
 	for (i = 0; i < (1 || Module['xml'].length); i++) {

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -8,6 +8,11 @@ xmllint.validateXML = function (options) {
 		TOTAL_MEMORY: options.TOTAL_MEMORY
 	}
 	;
+  if (options.format === 'rng') {
+		Module['extension'] = '--relaxng';
+	} else {
+		Module['extension'] = '--schema';
+	}
 
 	/* XMLLINT.RAW.JS */
 


### PR DESCRIPTION
Adds an optional field to the options given to the validateXML function.
If the user adds a field "format" with the content "rng", then the
argument used will be "--relaxng" instead of "--schema". Otherwise
"--schema" is used.