### PR TITLE
use  the latest released version of libxml2 (v2.13.1)

### DIFF
--- a/script/clean
+++ b/script/clean
@@ -2,4 +2,10 @@
 
 rm -rf ./build
 rm -rf ./libxml2/compile
-rm -rf ./libxml2/m4
+
+# some file in ./libxml2/m4 are provided by the project
+rm -f ./libxml2/m4/libtool.m4
+rm -f ./libxml2/m4/lt~obsolete.m4
+rm -f ./libxml2/m4/ltoptions.m4
+rm -f ./libxml2/m4/ltsugar.m4
+rm -f ./libxml2/m4/ltversion.m4

--- a/script/compile
+++ b/script/compile
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 emcc -O2 -s EMULATE_FUNCTION_POINTER_CASTS=1 \
-	--memory-init-file 0 \
-	./build/xmllint.o ./build/.libs/libxml2.a ./libz.a \
+	./build/xmllint-xmllint.o ./build/.libs/libxml2.so ./libz.a \
 	-o xmllint.raw.js --pre-js ./src/pre.js
 
 sed '/\/\* XMLLINT.RAW.JS \*\// {

--- a/script/libxml2
+++ b/script/libxml2
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 mkdir -p ./build
-mkdir -p ./libxml2/m4
 cd ./libxml2
 autoreconf -if -Wall
 cd ../build
-emconfigure ../libxml2/configure --with-http=no --with-ftp=no --with-python=no --with-threads=no
+emconfigure ../libxml2/configure --with-http=no --with-ftp=no --with-python=no --with-threads=no --with-modules=no
 emmake make
 cd ..

--- a/script/test
+++ b/script/test
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-emcc -O2 -s EMULATE_FUNCTION_POINTER_CASTS=1 ./build/xmllint.o \
-	./build/.libs/libxml2.a ./libz.a -o ./xmllint.test.js \
+emcc -O2 -s EMULATE_FUNCTION_POINTER_CASTS=1 ./build/xmllint-xmllint.o \
+	./build/.libs/libxml2.so ./libz.a -o ./xmllint.test.js \
 	--embed-file ./test/test.xml --embed-file ./test/test.xsd
 node ./xmllint.test.js --noout --schema ./test/test.xsd ./test/test.xml
 rm -rf ./xmllint.test.js


### PR DESCRIPTION
Small changes needed to the various xml.js build scripts

- libxml2 places some macro definition files in the `libxml2/m4` directory, so just delete any files placed there by local buid process
- latest version of `emcc` (used 3.1.61) does not support the `--memory-init-file 0` option 
- configure libxml2 to build withing using dynamic modules
- link static file into build